### PR TITLE
Trim whitespace from property name

### DIFF
--- a/lib/validate-decl.js
+++ b/lib/validate-decl.js
@@ -16,7 +16,7 @@ const validateValueAST = (ast, { result, customProperties, decl }) => {
 		ast.nodes.forEach(node => {
 			if (isVarFunction(node)) {
 				const [propertyNode, comma, ...fallbacks] = node.nodes.slice(1, -1); // eslint-disable-line no-unused-vars
-				const propertyName = String(propertyNode);
+				const propertyName = String(propertyNode).trim();
 
 				if (propertyName in customProperties) {
 					return;


### PR DESCRIPTION
We recently switched our project to use [`prettier`](https://prettier.io/) for code formatting which enforces a max length of lines. Some of our variable names are long and/or nested, requiring the `var()` function to be break onto multiple lines.

It seems that the `propertyNode` being tested as the property name is including all of the whitespace which causes the plugin to report an error even though the variable does exists. This change removes the whitespace in the `propertyName` definition before testing it.

With `prettier` formatting (lint error reported):
![Screenshot 2019-06-26 16 10 06](https://user-images.githubusercontent.com/5965968/60221074-24364f00-982d-11e9-8537-5230ebf90efb.png)

Same property, without `prettier` formatting (no error):
![Screenshot 2019-06-26 16 12 43](https://user-images.githubusercontent.com/5965968/60221103-3e702d00-982d-11e9-81d6-ca5720eaf853.png)
