### PR TITLE
support recursive @import statements

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -29,10 +29,13 @@ accept = [
 	{ code: 'html { --brand-blue: #33f; } body { color: var(--brand-blue); }' },
 	{ code: '* { --brand-blue: #33f; } body { color: var(--brand-blue); }' },
 	{ code: '.anything { --brand-blue: #33f; } body { color: var(--brand-blue); }' },
-	{ code: ':root { --brand-blue: #33f; --brand-color: var(--brand-blue); }' }
+	{ code: ':root { --brand-blue: #33f; --brand-color: var(--brand-blue); }' },
+	{ code: "@import './test/import-custom-properties.css'; body { color: var(--brand-red); }"},
+	{ code: "@import './test/import-custom-properties.css'; @import './test/import-custom-properties123.css'; body { color: var(--brand-red); }"}
 ];
 reject = [
-	{ code: 'body { color: var(--brand-blue); }' }
+	{ code: 'body { color: var(--brand-blue); }' },
+	{ code: "@import './test/import-custom-properties123.css'; body { color: var(--brand-red); }"}
 ];
 
 test(rule, { ruleName, skipBasicChecks, config: true, accept, reject });
@@ -82,7 +85,7 @@ test(rule, {
 });
 
 accept = [
-	{ code: 'body { background-color: var(--brand-red); border-color: var(--brand-white); color: var(--brand-blue); }' }
+	{ code: 'body { background-color: var(--brand-red); background: var(--brand-green); border-color: var(--brand-white); color: var(--brand-blue); }' }
 ];
 reject = [
 	{ code: 'body { color: var(--brand-blu); }' },

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default stylelint.createPlugin(ruleName, (method, opts) => {
 			// all custom properties from the file and imports
 			const customProperties = Object.assign(
 				await customPropertiesPromise,
-				getCustomPropertiesFromRoot(root)
+				await getCustomPropertiesFromRoot(root)
 			);
 
 			// validate the css root

--- a/src/lib/get-custom-properties-from-imports.js
+++ b/src/lib/get-custom-properties-from-imports.js
@@ -10,7 +10,7 @@ async function getCustomPropertiesFromCSSFile(from) {
 	const css = await readFile(from);
 	const root = postcss.parse(css, { from });
 
-	return getCustomPropertiesFromRoot(root);
+	return await getCustomPropertiesFromRoot(root);
 }
 
 /* Get Custom Properties from Object

--- a/src/lib/get-custom-properties-from-root.js
+++ b/src/lib/get-custom-properties-from-root.js
@@ -1,7 +1,29 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import postcss from 'postcss';
+
 // return custom selectors from the css root, conditionally removing them
-export default root => {
+export default async function getCustomPropertiesFromRoot(root) {
 	// initialize custom selectors
-	const customProperties = {};
+	let customProperties = {};
+
+	// resolve current file directory
+	let sourceDir = __dirname;
+	if (root.source && root.source.input && root.source.input.file) {
+		sourceDir = path.dirname(root.source.input.file);
+	}
+
+	// recursively add custom properties from @import statements
+	const importPromises = [];
+	root.walkAtRules('import', atRule => {
+		const fileName = atRule.params.replace(/['|"]/g, '');
+		const resolvedFileName = path.resolve(sourceDir, fileName);
+		importPromises.push(getCustomPropertiesFromCSSFile(resolvedFileName));
+	});
+
+	(await Promise.all(importPromises)).forEach(propertiesFromImport => {
+		customProperties = Object.assign(customProperties, propertiesFromImport);
+	});
 
 	// for each custom property declaration
 	root.walkDecls(customPropertyRegExp, decl => {
@@ -13,7 +35,19 @@ export default root => {
 
 	// return all custom properties, preferring :root properties over html properties
 	return customProperties;
-};
+}
 
 // match custom properties
 const customPropertyRegExp = /^--[A-z][\w-]*$/;
+
+
+async function getCustomPropertiesFromCSSFile(from) {
+	try {
+		const css = await fs.readFile(from, 'utf8');
+		const root = postcss.parse(css, { from });
+
+		return await getCustomPropertiesFromRoot(root);
+	} catch (e) {
+		return {};
+	}
+}

--- a/test/import-custom-properties-2.css
+++ b/test/import-custom-properties-2.css
@@ -1,0 +1,3 @@
+:root {
+	--brand-green: green;
+}

--- a/test/import-custom-properties.css
+++ b/test/import-custom-properties.css
@@ -1,3 +1,5 @@
+@import './import-custom-properties-2.css';
+
 :root {
 	--brand-red: red;
 }


### PR DESCRIPTION
Hi! I'd like to add a support for the `@import` statements to your plugin.

An example is described at the `33th` line of the test file.

A live use case is here:
1. let's imagine that you have some common css file with custom properties which you included in other css files
2. thanks to the `postcss-import` plugin you can append these properties to your main file
3. but stylelint cant resolve that import and always shows an error

The only way to fix the error is to use the static `importFrom` option in the plugin config. But this common file doesn't need to be included in **every** css file in the project

Included css file with custom properties:
![image](https://user-images.githubusercontent.com/14789714/90941781-be872800-e41b-11ea-85c5-98df7015e04f.png)

The css file with usage of these custom properties:
![image](https://user-images.githubusercontent.com/14789714/90942051-c1cee380-e41c-11ea-80c5-4688bfd8e260.png)

The similar issue is described here: #4
 
Actually maybe we should also add a resolve function to the plugin config?