### PR TITLE
Linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,11 @@
   "version": "3.0.0",
   "description": "A stylelint rule to disallow usage of unknown custom properties",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "license": "CC0-1.0",
-  "repository": "csstools/stylelint-value-no-unknown-custom-properties",
+  "repository": "https://github.com/csstools/stylelint-value-no-unknown-custom-properties",
   "homepage": "https://github.com/csstools/stylelint-value-no-unknown-custom-properties#readme",
   "bugs": "https://github.com/csstools/stylelint-value-no-unknown-custom-properties/issues",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm test",
     "pretest": "rollup -c .rollup.js --silent",
     "test": "npm run test:js && npm run test:tape",
-    "test:js": "eslint src/*.js --cache --ignore-path .gitignore --quiet",
+    "test:js": "eslint .*.js src --cache --ignore-path .gitignore --quiet",
     "test:tape": "tape ./.tape.js | tap-spec"
   },
   "engines": {

--- a/src/lib/validate-decl.js
+++ b/src/lib/validate-decl.js
@@ -15,7 +15,7 @@ const validateValueAST = (ast, { result, customProperties, decl }) => {
 	if (Object(ast.nodes).length) {
 		ast.nodes.forEach(node => {
 			if (isVarFunction(node)) {
-				const [propertyNode, comma, ...fallbacks] = node.nodes;
+				const [propertyNode, /* comma */, ...fallbacks] = node.nodes;
 				const propertyName = propertyNode.value;
 
 				if (propertyName in customProperties) {

--- a/src/lib/validate-result.js
+++ b/src/lib/validate-result.js
@@ -15,4 +15,3 @@ const customPropertyReferenceRegExp = /(^|[^\w-])var\([\W\w]+\)/;
 
 // whether a declaration references a custom property
 const hasCustomPropertyReference = decl => customPropertyReferenceRegExp.test(decl.value);
-


### PR DESCRIPTION
- Linting: Check all of src and test/config files
- Linting: Add linted package.json property `contributors` and use full URL for `repository` (can be cmd-clicked from IDEs to open in browser)
- Linting: Avoid unused var.
- Refactor: Drop extra EOF lb

Plan to also send some more substantive PRs on top of this (i.e., getting to 100% testing coverage and supporting the stylistic option to report custom property references which occur before declarations)...
