### PR TITLE
Resolve current file directory

### DIFF
--- a/src/lib/get-custom-properties-from-root.js
+++ b/src/lib/get-custom-properties-from-root.js
@@ -9,7 +9,7 @@ export default async function getCustomPropertiesFromRoot(root, resolver) {
 	let customProperties = {};
 
 	// resolve current file directory
-	let sourceDir = __dirname;
+	let sourceDir = process.cwd();
 	if (root.source && root.source.input && root.source.input.file) {
 		sourceDir = path.dirname(root.source.input.file);
 	}


### PR DESCRIPTION
**Summary**

Addresses failing tests, which was caused by `__dirname` resolving to `<root>/dist`. I believe the desired solution would be to check the current working directory.

See [this comment](https://github.com/csstools/stylelint-value-no-unknown-custom-properties/issues/24#issuecomment-1077284475).