### PR TITLE
Resolve value parser errors

### DIFF
--- a/src/lib/validate-decl.js
+++ b/src/lib/validate-decl.js
@@ -1,5 +1,5 @@
 import stylelint from 'stylelint';
-import { parse } from 'postcss-values-parser';
+import parse from 'postcss-value-parser';
 import ruleName from './rule-name';
 import messages from './messages';
 
@@ -12,37 +12,37 @@ export default (decl, { result, customProperties }) => {
 
 // validate a value ast
 const validateValueAST = (ast, { result, customProperties, decl }) => {
-	if (Object(ast.nodes).length) {
-		ast.nodes.forEach(node => {
-			if (isVarFunction(node)) {
-				const [propertyNode, comma, ...fallbacks] = node.nodes;
-				const propertyName = propertyNode.value;
-
-				if (propertyName in customProperties) {
-					return;
-				}
-
-				// conditionally test fallbacks
-				if (fallbacks.length) {
-					validateValueAST({ nodes: fallbacks.filter(isVarFunction) }, { result, customProperties, decl });
-
-					return;
-				}
-
-				// report unknown custom properties
-				stylelint.utils.report({
-					message: messages.unexpected(propertyName, decl.prop),
-					node: decl,
-					result,
-					ruleName,
-					word: String(propertyName),
-				});
-			} else {
-				validateValueAST(node, { result, customProperties, decl });
-			}
-		});
+	if (!Object(ast.nodes).length) {
+		return;
 	}
+	ast.nodes.forEach((node) => {
+		if (isVarFunction(node)) {
+			const { nodes } = node;
+			const [propertyNode, comma, ...fallbacks] = nodes;
+
+			if (!propertyNode || propertyNode.value in customProperties) {
+				return;
+			}
+
+			// conditionally test fallbacks
+			if (fallbacks.length) {
+				validateValueAST({ nodes: fallbacks.filter(isVarFunction) }, { result, customProperties, decl });
+				return;
+			}
+
+			// report unknown custom properties
+			stylelint.utils.report({
+				message: messages.unexpected(propertyNode.value, decl.prop),
+				node: decl,
+				result,
+				ruleName,
+				word: String(propertyNode.value),
+			});
+		} else {
+			validateValueAST(node, { result, customProperties, decl });
+		}
+	});
 };
 
 // whether the node is a var() function
-const isVarFunction = node => node.type === 'func' && node.name === 'var' && node.nodes[0].isVariable;
+const isVarFunction = node => node.type === 'function' && node.value === 'var';


### PR DESCRIPTION
**Summary**

Switches value parser from 'postcss-values-parser' to 'postcss-value-parser', which does not throw an exception when SCSS interpolation is used. This is also the same library which Stylelint uses for their value parser.

Closes #12.