### PR TITLE
Update stylelint peer dependency to include stylelint 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stylelint": "^14.6.0"
   },
   "peerDependencies": {
-    "stylelint": "10 - 14"
+    "stylelint": "10 - 15"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
Bumps peer dependency to fix: https://github.com/csstools/stylelint-value-no-unknown-custom-properties/issues/32

Some quick testing suggests that this plugin works fine with stylelint 15