### PR TITLE
feat: add basic alias resolver and @use support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,10 @@ Use this option to configure how the rule solve paths of `@import` rules.
       "resolver": {
         "extensions": [".css"], // => default to [".css"]
         "paths": ["./assets/css", "./static/css"], // => paths to look for files, default to []
-        "moduleDirectories": ["node_modules"] // => modules folder to look for files, default to ["node_modules"]
+        "moduleDirectories": ["node_modules"], // => modules folder to look for files, default to ["node_modules"]
+        "alias": {
+          "@": resolve(import.meta.dirname, 'src') // => Alias for import path
+        }
       }
     }]
   }

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -145,3 +145,30 @@ testRule({
 	accept,
 	reject,
 });
+
+/* Test enabled: { resolver: { alias } }
+/* ========================================================================== */
+
+accept = [
+	{ code: '@import \'@/import-custom-properties.css\'; body { color: var(--brand-red); }' },
+	{ code: '@import \'@test/import-custom-properties.css\'; body { color: var(--brand-red); }' },
+];
+reject = [
+	{ code: '@import \'@/import-custom-properties.css\'; body { color: var(--brand-re); }', message: messages.unexpected('--brand-re', 'color') },
+	{ code: '@import \'@/import-custom-properties.css\'; body { color: var(--brand-redz); }', message: messages.unexpected('--brand-redz', 'color') },
+];
+
+testRule({
+	plugins: ['.'],
+	ruleName: rule.ruleName,
+	config: [true, {
+		resolver: {
+			alias: {
+				'@': './test',
+				'@test': './test',
+			},
+		},
+	}],
+	accept,
+	reject,
+});


### PR DESCRIPTION
Hey 👋 

Related to #48 in a way. This PR add a basic alias resolver to follow aliased path in `@import`.
It's pretty straightforward by adding an alias map to the resolver options, and matching the path to it.

It also export the `getImportPromise` logic to facilitate `@use` support in the future (exemple : https://github.com/Lyliya/stylelint-value-no-unknown-custom-properties/pull/1)