### PR TITLE
Add checkVarsWithFallbacks option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to Stylelint Value No Unknown Custom Properties
 
+### 6.2.0
+
+- Add `checkVarsWithFallbacks` option to report custom properties as unknown even when a `var()` provides a fallback
+
 ### 6.1.1 (Jan 21, 2026)
 
 - Remove rogue `console.log` call

--- a/README.md
+++ b/README.md
@@ -136,6 +136,35 @@ Use this option to configure how the rule solve paths of `@import` rules.
 }
 ```
 
+### checkVarsWithFallbacks
+
+By default, when a `var()` reference supplies a fallback value, the rule does
+not report the outer custom property as unknown. Set `checkVarsWithFallbacks` to `true` to
+also flag the outer custom property as unknown even when a fallback is provided.
+
+```js
+// .stylelintrc
+{
+  "plugins": [
+    "stylelint-value-no-unknown-custom-properties"
+  ],
+  "rules": {
+    "csstools/value-no-unknown-custom-properties": [true, {
+      "checkVarsWithFallbacks": true
+    }]
+  }
+}
+```
+
+With `checkVarsWithFallbacks: true`, the following is reported as a violation
+because `--brand-blue` is never declared, even though a fallback is provided:
+
+```css
+.example {
+  color: var(--brand-blue, #33f);
+}
+```
+
 [discord]: https://discord.gg/bUadyRwkJS
 [discord-badge]: https://shields.io/badge/Discord-5865F2?logo=discord&logoColor=white
 [test-badge]: https://github.com/csstools/stylelint-value-no-unknown-custom-properties/actions/workflows/test.yml/badge.svg

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -75,6 +75,19 @@ reject = [
 ];
 testRule({ plugins: ['./src/index.mjs'], ruleName: rule.ruleName, config: true, accept, reject });
 
+/* Test fallbacks: { checkVarsWithFallbacks: true }
+/* ========================================================================== */
+
+accept = [
+	{ code: ':root { --brand-blue: #33f; } body { color: var(--brand-blue, #000); }', description: 'defined property with fallback still accepted' },
+	{ code: 'body { color: red; }', description: 'no var()' },
+];
+reject = [
+	{ code: 'body { color: var(--brand-blue, #33f); }', message: messages.unexpected('--brand-blue', 'color') },
+	{ code: 'body { color: var(--brand-blue, var(--brand-red)); }', warnings: [messages.unexpected('--brand-blue', 'color'), messages.unexpected('--brand-red', 'color')].map(message => ({ message })) },
+];
+testRule({ plugins: ['./src/index.mjs'], ruleName: rule.ruleName, config: [true, { checkVarsWithFallbacks: true }], accept, reject });
+
 /* Test enabled: not var()s
 /* ========================================================================== */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-value-no-unknown-custom-properties",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "A stylelint rule to disallow usage of unknown custom properties",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -13,6 +13,8 @@ const ruleFunction = (method, opts) => {
 	// sources to import custom selectors from
 	const importFrom = [].concat(Object(opts).importFrom || []);
 	const resolver = Object(opts).resolver || {};
+	// when true, validate var() references even if a fallback value is provided
+	const checkVarsWithFallbacks = Boolean(Object(opts).checkVarsWithFallbacks);
 
 	// promise any custom selectors are imported
 	const customPropertiesPromise = isMethodEnabled(method)
@@ -36,7 +38,7 @@ const ruleFunction = (method, opts) => {
 			);
 
 			// validate the css root
-			validateResult(root, result, customProperties);
+			validateResult(root, result, customProperties, { checkVarsWithFallbacks });
 		}
 	};
 };

--- a/src/lib/validate-decl.mjs
+++ b/src/lib/validate-decl.mjs
@@ -4,14 +4,14 @@ import ruleName from './rule-name.mjs';
 import messages from './messages.mjs';
 
 // validate css declarations
-export default (decl, { result, customProperties }) => {
+export default (decl, { result, customProperties, opts }) => {
 	const valueAST = valueParser(decl.value);
 
-	validateValueAST(valueAST, { result, customProperties, decl });
+	validateValueAST(valueAST, { result, customProperties, decl, opts: opts || {} });
 };
 
 // validate a value ast
-const validateValueAST = (ast, { result, customProperties, decl }) => {
+const validateValueAST = (ast, { result, customProperties, decl, opts }) => {
 	const isValid = typeof ast?.walk === 'function';
 
 	if (!isValid) {
@@ -27,11 +27,17 @@ const validateValueAST = (ast, { result, customProperties, decl }) => {
 				return;
 			}
 
-			// conditionally test fallbacks
+			// when a fallback is provided we still need to walk it so we can
+			// surface unknown custom properties referenced inside the fallback
 			if (fallbacks.length) {
-				validateValueAST({ nodes: fallbacks.filter(isVarFunction) }, { result, customProperties, decl });
+				validateValueAST({ nodes: fallbacks.filter(isVarFunction) }, { result, customProperties, decl, opts });
 
-				return;
+				// by default, the presence of a fallback suppresses the warning
+				// on the outer var(). When `checkVarsWithFallbacks` is enabled,
+				// the outer reference is still reported even though a fallback exists.
+				if (!opts.checkVarsWithFallbacks) {
+					return;
+				}
 			}
 
 			// report unknown custom properties

--- a/src/lib/validate-result.mjs
+++ b/src/lib/validate-result.mjs
@@ -1,11 +1,11 @@
 import validateDecl from './validate-decl.mjs';
 
 // validate the css root
-export default (root, result, customProperties) => {
+export default (root, result, customProperties, opts = {}) => {
 	// validate each declaration
 	root.walkDecls(decl => {
 		if (hasCustomPropertyReference(decl)) {
-			validateDecl(decl, { result, customProperties });
+			validateDecl(decl, { result, customProperties, opts });
 		}
 	});
 };
@@ -15,4 +15,3 @@ const customPropertyReferenceRegExp = /(^|[^\w-])var\([\W\w]+\)/i;
 
 // whether a declaration references a custom property
 const hasCustomPropertyReference = decl => customPropertyReferenceRegExp.test(decl.value);
-


### PR DESCRIPTION
Hello! I really like this lint rule, but I found myself really wishing it would catch unknown vars even if there was a fallback. This PR adds support for a `checkVarsWithFallbacks` option that does just that. Please let me know if you have any questions, or if this PR needs any modifications to meet your standards. I do not want to burden you with this change, but I would really appreciate having this feature approved.

Thanks again!