### PR TITLE
Declare postcss as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.1.1",
       "license": "CC0-1.0",
       "dependencies": {
+        "postcss": "^8.4.0",
         "postcss-value-parser": "^4.2.0",
         "resolve": "^1.22.8"
       },
@@ -1025,7 +1026,6 @@
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1102,7 +1102,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -1122,7 +1121,6 @@
       "version": "8.5.22",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
       "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1363,7 +1361,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node": ">=18.12.0"
   },
   "dependencies": {
+    "postcss": "^8.4.0",
     "postcss-value-parser": "^4.2.0",
     "resolve": "^1.22.8"
   },


### PR DESCRIPTION
Fixes #66.

`src/lib/get-custom-properties-from-root.mjs` and `src/lib/get-custom-properties-from-imports.mjs` import `postcss`, but it was never declared, so plugin load fails under package managers with isolated `node_modules` (pnpm's default). npm users never see it because stylelint pulls postcss in through hoisting.

One line in `package.json` plus the lockfile sync. `^8.4.0` sits inside what the stylelint peer range already implies, so it adds no constraint for consumers. `npm test` passes, 51/51.
